### PR TITLE
Fix UnboundLocalError in Log class

### DIFF
--- a/dashing/dashing.py
+++ b/dashing/dashing.py
@@ -266,9 +266,9 @@ class Log(Tile):
             line = self.logs[start + i]
             print(tbox.t.move(tbox.x + i, tbox.y) + line + " " * (tbox.w - len(line)))
 
-        if i < tbox.h:
-            for i2 in range(i + 1, tbox.h):
-                print(tbox.t.move(tbox.x + i2, tbox.y) + " " * tbox.w)
+            if i < tbox.h:
+                for i2 in range(i + 1, tbox.h):
+                    print(tbox.t.move(tbox.x + i2, tbox.y) + " " * tbox.w)
 
     def append(self, msg):
         """Append a new log message at the bottom"""


### PR DESCRIPTION
I came across the following error while building a dashing dashboard (paths truncated in traceback for brevity):

```
  File "venv/lib/python3.9/site-packages/dashing/dashing.py", line 100, in display
    self._display(tbox, None)
  File "venv/lib/python3.9/site-packages/dashing/dashing.py", line 144, in _display
    i._display(TBox(tbox.t, x, y, item_width, item_height), self)
  File "venv/lib/python3.9/site-packages/dashing/dashing.py", line 144, in _display
    i._display(TBox(tbox.t, x, y, item_width, item_height), self)
  File "venv/lib/python3.9/site-packages/dashing/dashing.py", line 144, in _display
    i._display(TBox(tbox.t, x, y, item_width, item_height), self)
  File "venv/lib/python3.9/site-packages/dashing/dashing.py", line 205, in _display
    if i < tbox.h:
UnboundLocalError: local variable 'i' referenced before assignment
```

This patch is a quick fix for this particular error.