### PR TITLE
Update dashing.py to fix bug

### DIFF
--- a/dashing/dashing.py
+++ b/dashing/dashing.py
@@ -262,10 +262,12 @@ class Log(Tile):
         log_range = min(n_logs, tbox.h)
         start = n_logs - log_range
         print(tbox.t.color(self.color))
+        
+        i = 0
         for i in range(0, log_range):
             line = self.logs[start + i]
             print(tbox.t.move(tbox.x + i, tbox.y) + line + " " * (tbox.w - len(line)))
-
+        
         if i < tbox.h:
             for i2 in range(i + 1, tbox.h):
                 print(tbox.t.move(tbox.x + i2, tbox.y) + " " * tbox.w)


### PR DESCRIPTION
When runing `demo.py` with python 3.8.3 in VS Code intergrated terminal, an error, namely `UnboundLocalError`, occurs saying `local variable 'i' referenced before assignment`. This pull request is for fixing the bug,

Environments: Windows 10, VS Code Integrated Terminal, Python 3.8.3, dashing 0.1.0.

