### PR TITLE
Add `Color` enum

### DIFF
--- a/dashing/__init__.py
+++ b/dashing/__init__.py
@@ -87,7 +87,7 @@ Color = Literal[0, 1, 2, 3, 4, 5, 6, 7]
 Colormap = Tuple[Tuple[float, Color], ...]
 
 
-class Tile(object):
+class Tile:
     def __init__(self, title: str = None, border_color: Color = None, color: Color = 0):
         self.title = title
         self.color = color

--- a/dashing/__init__.py
+++ b/dashing/__init__.py
@@ -60,6 +60,7 @@ You can easily nest splits and tiles as in::
 
 __version__ = "0.1.0"
 
+import abc
 import contextlib
 import itertools
 from collections import deque, namedtuple
@@ -101,7 +102,7 @@ Colormap = Tuple[Tuple[float, ColorValue], ...]
 TBox = namedtuple("TBox", "t x y w h")
 
 
-class Tile:
+class Tile(abc.ABC):
     def __init__(
         self,
         title: str = None,
@@ -113,9 +114,10 @@ class Tile:
         self.border_color = border_color
         self._terminal: Optional[Terminal] = None
 
+    @abc.abstractmethod
     def _display(self, tbox: TBox, parent: Optional["Tile"]):
         """Render current tile"""
-        raise NotImplementedError
+        pass
 
     def _draw_borders_and_title(self, tbox: TBox):
         """

--- a/dashing/__init__.py
+++ b/dashing/__init__.py
@@ -63,7 +63,8 @@ __version__ = "0.1.0"
 import contextlib
 import itertools
 from collections import deque, namedtuple
-from typing import Literal, Optional, Tuple
+from enum import Enum
+from typing import Literal, Optional, Tuple, Union
 
 from blessed import Terminal
 
@@ -82,13 +83,31 @@ braille_right = (0x08, 0x10, 0x20, 0x80, 0)
 braille_r_left = (0x04, 0x02, 0x01)
 braille_r_right = (0x20, 0x10, 0x08)
 
+
+class Color(Enum):
+    Black = 0
+    Red = 1
+    Green = 2
+    Yellow = 3
+    Blue = 4
+    Magenta = 5
+    Cyan = 6
+    White = 7
+
+
+ColorLiteral = Literal[0, 1, 2, 3, 4, 5, 6, 7]
+ColorValue = Union[Color, ColorLiteral]
+Colormap = Tuple[Tuple[float, ColorValue], ...]
 TBox = namedtuple("TBox", "t x y w h")
-Color = Literal[0, 1, 2, 3, 4, 5, 6, 7]
-Colormap = Tuple[Tuple[float, Color], ...]
 
 
 class Tile:
-    def __init__(self, title: str = None, border_color: Color = None, color: Color = 0):
+    def __init__(
+        self,
+        title: str = None,
+        border_color: ColorValue = None,
+        color: ColorValue = Color.Black,
+    ):
         self.title = title
         self.color = color
         self.border_color = border_color
@@ -227,7 +246,7 @@ class Text(Tile):
 
     """
 
-    def __init__(self, text: str, color: Color = 0, **kw):
+    def __init__(self, text: str, color: ColorValue = Color.Black, **kw):
         super().__init__(**kw)
         self.text: str = text
         self.color = color
@@ -269,7 +288,9 @@ class Log(Tile):
 class HGauge(Tile):
     """Horizontal gauge"""
 
-    def __init__(self, label: str = None, val=100, color: Color = 2, **kw):
+    def __init__(
+        self, label: str = None, val=100, color: ColorValue = Color.Green, **kw
+    ):
         super().__init__(color=color, **kw)
         self.value = val
         self.label = label
@@ -306,7 +327,7 @@ class HGauge(Tile):
 class VGauge(Tile):
     """Vertical gauge"""
 
-    def __init__(self, val=100, color: Color = 2, **kw):
+    def __init__(self, val=100, color: ColorValue = Color.Green, **kw):
         super().__init__(color=color, **kw)
         self.value = val
 

--- a/dashing/__init__.py
+++ b/dashing/__init__.py
@@ -64,7 +64,7 @@ import abc
 import contextlib
 import itertools
 from collections import deque, namedtuple
-from enum import Enum
+from enum import IntEnum
 from typing import Literal, Optional, Tuple, Union
 
 from blessed import Terminal
@@ -85,7 +85,7 @@ braille_r_left = (0x04, 0x02, 0x01)
 braille_r_right = (0x20, 0x10, 0x08)
 
 
-class Color(Enum):
+class Color(IntEnum):
     Black = 0
     Red = 1
     Green = 2


### PR DESCRIPTION
closes #12. Adds a backwards compatible `IntEnum` that can be used wherever color is used now. Also removed the last occurence of py2 style classes, and use an abstract base class to enforce that subclasses of `Tile` must implement `_display`.

(This PR is just a temporary fix while I work on adding full Blessed foreground, background, border, title color support)