### PR TITLE
Multiline text tile family

### DIFF
--- a/dashing/__init__.py
+++ b/dashing/__init__.py
@@ -60,10 +60,12 @@ You can easily nest splits and tiles as in::
 
 __version__ = "0.1.0"
 
+import abc
 import contextlib
 import itertools
 from collections import deque, namedtuple
-from typing import Literal, Optional, Tuple
+from enum import IntEnum
+from typing import Iterable, Literal, Optional, Sequence, Tuple
 
 from blessed import Terminal
 
@@ -85,6 +87,16 @@ braille_r_right = (0x20, 0x10, 0x08)
 TBox = namedtuple("TBox", "t x y w h")
 Color = Literal[0, 1, 2, 3, 4, 5, 6, 7]
 Colormap = Tuple[Tuple[float, Color], ...]
+
+
+class Side(IntEnum):
+    Left = 0
+    Right = 1
+
+
+class Clip(IntEnum):
+    Head = 0
+    Tail = 1
 
 
 class Tile(object):


### PR DESCRIPTION
I tried factoring out the commonalities of multiline text tiles (limit them to available lines and character columns with ellipsis overflow) and added a new double column text tile with a separator, and some alignment and truncation options, e.g.:

```
Hello:       world
Goodbye:       all
See you ag…: later
```

It's a draft for now, because I'm not sure the naming of the configurable options is clear enough, and I'd like to add tests, but go ahead if you already want to have a first look and some review!

It's probably also possible to add an infinite amount of tiles to `dashing`, so it might make sense to think of some inclusion policy of what we'd want to include in the main package, and what tiles we'd suggest the community to just publish in their own package.